### PR TITLE
allow qualname to work on code objects

### DIFF
--- a/qualname.py
+++ b/qualname.py
@@ -63,6 +63,9 @@ def qualname(obj):
         except AttributeError:
             code = obj.func_code
         lineno = code.co_firstlineno
+    elif inspect.iscode(obj):
+        code = obj
+        lineno = code.co_firstlineno
     else:
         return obj.__qualname__  # raises a sensible error
 


### PR DESCRIPTION
Although Python 3 code objects don't have a `__qualname__`, it might come in handy for qualname() to work on code objects as well.
