### PR TITLE
Fix case when inspect.getsourcefile() returns None

### DIFF
--- a/qualname.py
+++ b/qualname.py
@@ -49,6 +49,8 @@ def qualname(obj):
         filename = inspect.getsourcefile(obj)
     except TypeError:
         return obj.__qualname__  # raises a sensible error
+    if not filename:
+        return obj.__qualname__  # raises a sensible error
     if inspect.isclass(obj):
         try:
             _, lineno = inspect.getsourcelines(obj)


### PR DESCRIPTION
With Python 2 it would later fail on `with open(filename, 'r') as fp` with:
`TypeError: coercing to Unicode: need string or buffer, NoneType found`